### PR TITLE
Add Colab usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [[Paper]](https://arxiv.org/abs/2212.04356)
 [[Model card]](https://github.com/openai/whisper/blob/main/model-card.md)
 [[Colab example]](https://colab.research.google.com/github/openai/whisper/blob/master/notebooks/LibriSpeech.ipynb)
+[[Transcribe your own audio in Colab]](https://colab.research.google.com/github/openai/whisper/blob/master/notebooks/Colab_Whisper_Transcription.ipynb)
 
 Whisper is a general-purpose speech recognition model. It is trained on a large dataset of diverse audio and is also a multitasking model that can perform multilingual speech recognition, speech translation, and language identification.
 
@@ -139,6 +140,21 @@ result = whisper.decode(model, mel, options)
 # print the recognized text
 print(result.text)
 ```
+
+## Google Colab
+
+You can run Whisper directly in your browser using
+[this Colab notebook](https://colab.research.google.com/github/openai/whisper/blob/master/notebooks/Colab_Whisper_Transcription.ipynb).
+One of the early cells lets you upload an audio file:
+
+```python
+from google.colab import files
+uploaded = files.upload()
+audio_path = next(iter(uploaded))
+```
+
+Execute that cell to select your audio file, then run the next cell in the
+notebook to generate the transcription.
 
 ## More examples
 

--- a/notebooks/Colab_Whisper_Transcription.ipynb
+++ b/notebooks/Colab_Whisper_Transcription.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transcribe Audio with Whisper in Google Colab\n",
+    "This notebook demonstrates how to upload an audio file and transcribe it using [OpenAI Whisper](https://github.com/openai/whisper) directly in Google Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Install Whisper\n",
+    "!pip install -q git+https://github.com/openai/whisper.git"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Upload an audio file\n",
+    "from google.colab import files\n",
+    "uploaded = files.upload()\n",
+    "audio_path = next(iter(uploaded))"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Load Whisper and transcribe\n",
+    "import whisper\n",
+    "model = whisper.load_model('base')\n",
+    "result = model.transcribe(audio_path)\n",
+    "print(result['text'])"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## Summary
- add a new section in the README describing how to run Whisper in Google Colab
- highlight the upload cell in the example notebook link

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*